### PR TITLE
Use desiredLRPSchedulingInfos instead of desiredLRPs

### DIFF
--- a/routing_table/schema/endpoint/endpoint.go
+++ b/routing_table/schema/endpoint/endpoint.go
@@ -3,6 +3,7 @@ package endpoint
 import (
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/routing-info/tcp_routes"
 )
 
 type EndpointKey struct {
@@ -108,10 +109,10 @@ func NewRoutingKeysFromActual(actualGrp *models.ActualLRPGroup) RoutingKeys {
 	return keys
 }
 
-func NewRoutingKeysFromDesired(desired *models.DesiredLRP) RoutingKeys {
+func NewRoutingKeysFromDesired(processGuid string, routes tcp_routes.TCPRoutes) RoutingKeys {
 	keys := RoutingKeys{}
-	for _, containerPort := range desired.Ports {
-		keys = append(keys, NewRoutingKey(desired.ProcessGuid, containerPort))
+	for _, route := range routes {
+		keys = append(keys, NewRoutingKey(processGuid, route.ContainerPort))
 	}
 
 	return keys

--- a/routing_table/schema/endpoint/endpoint_utils_test.go
+++ b/routing_table/schema/endpoint/endpoint_utils_test.go
@@ -111,15 +111,8 @@ var _ = Describe("LRP Utils", func() {
 				{ExternalPort: 61001, ContainerPort: 9090},
 			}
 
-			desired := &models.DesiredLRP{
-				Domain:      "tests",
-				ProcessGuid: "process-guid",
-				Ports:       []uint32{8080, 9090},
-				Routes:      routes.RoutingInfo(),
-				LogGuid:     "abc-guid",
-			}
-
-			keys := endpoint.NewRoutingKeysFromDesired(desired)
+			processGuid := "process-guid"
+			keys := endpoint.NewRoutingKeysFromDesired(processGuid, routes)
 
 			Expect(keys).To(HaveLen(2))
 			Expect(keys).To(ContainElement(endpoint.NewRoutingKey("process-guid", 8080)))
@@ -128,19 +121,12 @@ var _ = Describe("LRP Utils", func() {
 
 		Context("when the desired LRP does not define any container ports", func() {
 			It("returns no keys", func() {
-				routes := tcp_routes.TCPRoutes{
-					{ExternalPort: 61000, ContainerPort: 8080},
-				}
+				routes := tcp_routes.TCPRoutes{}
+				processGuid := "process-guid"
 
-				desired := &models.DesiredLRP{
-					Domain:      "tests",
-					ProcessGuid: "process-guid",
-					Routes:      routes.RoutingInfo(),
-					LogGuid:     "abc-guid",
-				}
-
-				keys := endpoint.NewRoutingKeysFromDesired(desired)
+				keys := endpoint.NewRoutingKeysFromDesired(processGuid, routes)
 				Expect(keys).To(HaveLen(0))
+
 			})
 		})
 	})

--- a/routing_table/schema/fakes/fake_routing_table.go
+++ b/routing_table/schema/fakes/fake_routing_table.go
@@ -16,27 +16,27 @@ type FakeRoutingTable struct {
 	routeCountReturns     struct {
 		result1 int
 	}
-	AddRoutesStub        func(desiredLRP *models.DesiredLRP) event.RoutingEvents
+	AddRoutesStub        func(desiredLRP *models.DesiredLRPSchedulingInfo) event.RoutingEvents
 	addRoutesMutex       sync.RWMutex
 	addRoutesArgsForCall []struct {
-		desiredLRP *models.DesiredLRP
+		desiredLRP *models.DesiredLRPSchedulingInfo
 	}
 	addRoutesReturns struct {
 		result1 event.RoutingEvents
 	}
-	UpdateRoutesStub        func(beforeLRP, afterLRP *models.DesiredLRP) event.RoutingEvents
+	UpdateRoutesStub        func(beforeLRP, afterLRP *models.DesiredLRPSchedulingInfo) event.RoutingEvents
 	updateRoutesMutex       sync.RWMutex
 	updateRoutesArgsForCall []struct {
-		beforeLRP *models.DesiredLRP
-		afterLRP  *models.DesiredLRP
+		beforeLRP *models.DesiredLRPSchedulingInfo
+		afterLRP  *models.DesiredLRPSchedulingInfo
 	}
 	updateRoutesReturns struct {
 		result1 event.RoutingEvents
 	}
-	RemoveRoutesStub        func(desiredLRP *models.DesiredLRP) event.RoutingEvents
+	RemoveRoutesStub        func(desiredLRP *models.DesiredLRPSchedulingInfo) event.RoutingEvents
 	removeRoutesMutex       sync.RWMutex
 	removeRoutesArgsForCall []struct {
-		desiredLRP *models.DesiredLRP
+		desiredLRP *models.DesiredLRPSchedulingInfo
 	}
 	removeRoutesReturns struct {
 		result1 event.RoutingEvents
@@ -97,10 +97,10 @@ func (fake *FakeRoutingTable) RouteCountReturns(result1 int) {
 	}{result1}
 }
 
-func (fake *FakeRoutingTable) AddRoutes(desiredLRP *models.DesiredLRP) event.RoutingEvents {
+func (fake *FakeRoutingTable) AddRoutes(desiredLRP *models.DesiredLRPSchedulingInfo) event.RoutingEvents {
 	fake.addRoutesMutex.Lock()
 	fake.addRoutesArgsForCall = append(fake.addRoutesArgsForCall, struct {
-		desiredLRP *models.DesiredLRP
+		desiredLRP *models.DesiredLRPSchedulingInfo
 	}{desiredLRP})
 	fake.addRoutesMutex.Unlock()
 	if fake.AddRoutesStub != nil {
@@ -116,7 +116,7 @@ func (fake *FakeRoutingTable) AddRoutesCallCount() int {
 	return len(fake.addRoutesArgsForCall)
 }
 
-func (fake *FakeRoutingTable) AddRoutesArgsForCall(i int) *models.DesiredLRP {
+func (fake *FakeRoutingTable) AddRoutesArgsForCall(i int) *models.DesiredLRPSchedulingInfo {
 	fake.addRoutesMutex.RLock()
 	defer fake.addRoutesMutex.RUnlock()
 	return fake.addRoutesArgsForCall[i].desiredLRP
@@ -129,11 +129,11 @@ func (fake *FakeRoutingTable) AddRoutesReturns(result1 event.RoutingEvents) {
 	}{result1}
 }
 
-func (fake *FakeRoutingTable) UpdateRoutes(beforeLRP *models.DesiredLRP, afterLRP *models.DesiredLRP) event.RoutingEvents {
+func (fake *FakeRoutingTable) UpdateRoutes(beforeLRP *models.DesiredLRPSchedulingInfo, afterLRP *models.DesiredLRPSchedulingInfo) event.RoutingEvents {
 	fake.updateRoutesMutex.Lock()
 	fake.updateRoutesArgsForCall = append(fake.updateRoutesArgsForCall, struct {
-		beforeLRP *models.DesiredLRP
-		afterLRP  *models.DesiredLRP
+		beforeLRP *models.DesiredLRPSchedulingInfo
+		afterLRP  *models.DesiredLRPSchedulingInfo
 	}{beforeLRP, afterLRP})
 	fake.updateRoutesMutex.Unlock()
 	if fake.UpdateRoutesStub != nil {
@@ -149,7 +149,7 @@ func (fake *FakeRoutingTable) UpdateRoutesCallCount() int {
 	return len(fake.updateRoutesArgsForCall)
 }
 
-func (fake *FakeRoutingTable) UpdateRoutesArgsForCall(i int) (*models.DesiredLRP, *models.DesiredLRP) {
+func (fake *FakeRoutingTable) UpdateRoutesArgsForCall(i int) (*models.DesiredLRPSchedulingInfo, *models.DesiredLRPSchedulingInfo) {
 	fake.updateRoutesMutex.RLock()
 	defer fake.updateRoutesMutex.RUnlock()
 	return fake.updateRoutesArgsForCall[i].beforeLRP, fake.updateRoutesArgsForCall[i].afterLRP
@@ -162,10 +162,10 @@ func (fake *FakeRoutingTable) UpdateRoutesReturns(result1 event.RoutingEvents) {
 	}{result1}
 }
 
-func (fake *FakeRoutingTable) RemoveRoutes(desiredLRP *models.DesiredLRP) event.RoutingEvents {
+func (fake *FakeRoutingTable) RemoveRoutes(desiredLRP *models.DesiredLRPSchedulingInfo) event.RoutingEvents {
 	fake.removeRoutesMutex.Lock()
 	fake.removeRoutesArgsForCall = append(fake.removeRoutesArgsForCall, struct {
-		desiredLRP *models.DesiredLRP
+		desiredLRP *models.DesiredLRPSchedulingInfo
 	}{desiredLRP})
 	fake.removeRoutesMutex.Unlock()
 	if fake.RemoveRoutesStub != nil {
@@ -181,7 +181,7 @@ func (fake *FakeRoutingTable) RemoveRoutesCallCount() int {
 	return len(fake.removeRoutesArgsForCall)
 }
 
-func (fake *FakeRoutingTable) RemoveRoutesArgsForCall(i int) *models.DesiredLRP {
+func (fake *FakeRoutingTable) RemoveRoutesArgsForCall(i int) *models.DesiredLRPSchedulingInfo {
 	fake.removeRoutesMutex.RLock()
 	defer fake.removeRoutesMutex.RUnlock()
 	return fake.removeRoutesArgsForCall[i].desiredLRP

--- a/routing_table/util/lrp_utils.go
+++ b/routing_table/util/lrp_utils.go
@@ -19,6 +19,17 @@ func DesiredLRPData(lrp *models.DesiredLRP) lager.Data {
 	}
 }
 
+func DesiredLRPSchedulingInfoData(lrpInfo *models.DesiredLRPSchedulingInfo) lager.Data {
+	logRoutes := make(models.Routes)
+	logRoutes[cfroutes.CF_ROUTER] = (lrpInfo.Routes)[cfroutes.CF_ROUTER]
+	logRoutes[tcp_routes.TCP_ROUTER] = (lrpInfo.Routes)[tcp_routes.TCP_ROUTER]
+
+	return lager.Data{
+		"process-guid": lrpInfo.ProcessGuid,
+		"routes":       logRoutes,
+	}
+}
+
 func ActualLRPData(lrp *models.ActualLRP, evacuating bool) lager.Data {
 	return lager.Data{
 		"process-guid":  lrp.ProcessGuid,
@@ -30,5 +41,16 @@ func ActualLRPData(lrp *models.ActualLRP, evacuating bool) lager.Data {
 		"ports":         lrp.Ports,
 		"evacuating":    evacuating,
 		"state":         lrp.State,
+	}
+}
+
+func DesiredLRPSchedulingInfo(desiredLRP *models.DesiredLRP) *models.DesiredLRPSchedulingInfo {
+	return &models.DesiredLRPSchedulingInfo{
+		DesiredLRPKey: models.DesiredLRPKey{
+			ProcessGuid: desiredLRP.ProcessGuid,
+			LogGuid:     desiredLRP.LogGuid,
+		},
+		Routes:          *desiredLRP.Routes,
+		ModificationTag: *desiredLRP.ModificationTag,
 	}
 }


### PR DESCRIPTION
  - reduces amount of data fetched from bbs when syncing

[#145945785]

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>